### PR TITLE
Korjaus tehtävien tekemisen kohtaan

### DIFF
--- a/osa3.md
+++ b/osa3.md
@@ -1826,7 +1826,7 @@ Backend vaikuttaa toimivan postmanista VS Code REST clientistä tehtyjen kokeilu
 
 ### Tehtäviä
 
-Tee nyt tehtävät [3.16-3.19](/tehtävät#lisää-operaatioita)
+Tee nyt tehtävät [3.16-3.18](/tehtävät#lisää-operaatioita)
 
 ## Refaktorointia - promisejen ketjutus
 


### PR DESCRIPTION
Tehtävä 3.19 neuvottiin tekemään kahdessa eri kohtaa joista ensimmäinen tulee ennen kuin materiaalissa käsitellään promisejen ketjutusta. Tämä aiheutti itselläni hieman päänvaivaa kun en huomannut, että aihetta käsiteltiin materiaalissa vasta myöhemmin. Korjasin sen niin, että 3.19 neuvotaan tekemään vasta promisejen ketjutus- materiaalin jälkeen niin muille ei toivottavasti tule samantapaisia ongelmia.