### PR TITLE
Don't supply Promise implementation to Mongoose

### DIFF
--- a/osa3.md
+++ b/osa3.md
@@ -1327,7 +1327,6 @@ const mongoose = require('mongoose')
 const url = 'mongodb://fullstack:sekred@ds211088.mlab.com:11088/fullstack-notes'
 
 mongoose.connect(url)
-mongoose.Promise = global.Promise;
 
 const Note = mongoose.model('Note', {
   content: String,
@@ -1365,7 +1364,6 @@ const mongoose = require('mongoose')
 const url = 'mongodb://fullstack:fullstack@ds211088.mlab.com:11088/fullstack-notes'
 
 mongoose.connect(url)
-mongoose.Promise = global.Promise
 ```
 
 Valitettavasti mongoosen dokumentaatiossa käytetään joka paikassa takaisinkutsufunktioita, joten sieltä ei kannata suoraan copypasteta koodia, sillä promisejen ja vanhanaikaisten callbackien sotkeminen samaan koodiin ei ole kovin järkevää.
@@ -1482,7 +1480,6 @@ const mongoose = require('mongoose')
 const url = 'mongodb://fullstack:sekred@ds211088.mlab.com:11088/fullstack-notes'
 
 mongoose.connect(url)
-mongoose.Promise = global.Promise
 
 const Note = mongoose.model('Note', {
   content: String,
@@ -1582,7 +1579,6 @@ const mongoose = require('mongoose')
 const url = 'mongodb://fullstack:sekred@ds211088.mlab.com:11088/fullstack-notes'
 
 mongoose.connect(url)
-mongoose.Promise = global.Promise
 
 const Note = mongoose.model('Note', {
   content: String,


### PR DESCRIPTION
Mongoose should return ES6 promises as of version 5 which was released 2018-01-17. Documentation can be found here: http://mongoosejs.com/docs/promises.html

> Mongoose async operations, like .save() and queries, return ES6 promises. This means that you can do things like MyModel.findOne({}).then() and await MyModel.findOne({}).exec() (if you're using async/await.