### PR TITLE
Tehtävä 3.12 doublequotet

### DIFF
--- a/tehtavat.md
+++ b/tehtavat.md
@@ -1059,7 +1059,7 @@ lisätään henkilö Joulupukki numero 040-1234556 luetteloon
 ja lisää uuden yhteystiedon tietokantaan. Huomaa, että jos nimi sisältää välilyöntejä, on se annettava hipsuissa:
 
 ```bash
-node mongo.js 'Arto Vihavainen' 040-1234556
+node mongo.js "Arto Vihavainen" 040-1234556
 ```
 
 Jos komentoriviparametreja ei anneta, eli ohjelma suoritetaan komennolla


### PR DESCRIPTION
Ainakin Windowsissa singlequoteja käyttämällä nimi jakautuu silti kahdeksi eri parametriksi, mutta doublequoteilla toimii oikein.