### PR TITLE
bootstrapin stylesheet-linkki

### DIFF
--- a/osa6.md
+++ b/osa6.md
@@ -2022,7 +2022,7 @@ Lisätään sitten sovelluksen _public/index.html_ tiedoston _head_-tagin sisä�
 
 ```html
 <head>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   // ...
 </head>
 ```


### PR DESCRIPTION
aiempi "latest" bootstrap.min.css rikkoi Navbarin tyylit, korvattu osoitteesta https://react-bootstrap.github.io/getting-started/introduction kopioidulla