### PR TITLE
delete -testifunktiossa ('a note can be deleted') pitää mielestäni ol…

### DIFF
--- a/osa4.md
+++ b/osa4.md
@@ -1267,7 +1267,7 @@ test('a note can be deleted', async () => {
     .get('/api/notes')
 
   await api
-    .delete(`/api/notes/${addedNote.body.id}`)
+    .delete(`/api/notes/${addedNote.body._id}`)
     .expect(204)
 
   const notesAfterDelete = await api


### PR DESCRIPTION
…la addedNote.body._id eikä id. Post-funktio ei palauta kai formatoitua notea. Ainakin testi deletellä meni läpi tuon muutoksen jälkeen.