### PR TITLE
Webpack config fix

### DIFF
--- a/osa7.md
+++ b/osa7.md
@@ -307,7 +307,7 @@ const config = {
     filename: 'bundle.js'
   },
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.js$/,
         loader: 'babel-loader',
@@ -320,7 +320,7 @@ const config = {
 }
 ```
 
-Loaderit määritellään kentän _module_ alle sijoitettavaan taulukkoon _loaders_.
+Loaderit määritellään kentän _module_ alle sijoitettavaan taulukkoon _rules_.
 
 Yksittäisen loaderin määrittely on kolmiosainen:
 


### PR DESCRIPTION
s/loaders/rules, niin toimii myös juuri julkaistulla Webpack 4:lla.

Materiaaliin voisi myös muotoilla, että Webpack 4 sisältää vivut --mode=production ja --mode=development, joista varoittelee buildauksen yhteydessä jos jää asettamatta. Production mode sisältää esim. koodin minifioinnin ja development kehitysaikaisia optimointeja+helpotuksia. 

[https://medium.com/webpack/webpack-4-mode-and-optimization-5423a6bc597a]