### PR TITLE
Remove unused variable assignment from test

### DIFF
--- a/osa4.md
+++ b/osa4.md
@@ -1101,8 +1101,6 @@ test('note without content is not added ', async () => {
   const response = await api
     .get('/api/notes')
 
-  const contents = response.body.map(r => r.content)
-
   expect(response.body.length).toBe(intialNotes.body.length)
 })
 ```


### PR DESCRIPTION
test body was probably copied from the other test `'a valid note can be added'`, and the author forgot to remove the variable assignment.