### PR TITLE
Fix componentDidMount link anchor week 6

### DIFF
--- a/osa6.md
+++ b/osa6.md
@@ -1189,7 +1189,7 @@ noteService.getAll().then(notes =>
 > await toimii ainoastaan _async_-funktioiden sisällä, ja _index.js_:ssä oleva koodi ei ole funktiossa, joten päädyimme tilanteen yksinkertaisuuden takia tällä kertaa jättämään _async_:in käyttämättä.
 
 
-Päätetään kuitenkin siirtää muistiinpanojen alustus _App_-komponentin metodiin _[componentDidMount](https://reactjs.org/docs/react-component.html#componentDidMount)_, se on luonteva paikka alustuksille, sillä metodi suoritetaan ennen kuin sovelluksemme renderöidään ensimmäistä kertaa.
+Päätetään kuitenkin siirtää muistiinpanojen alustus _App_-komponentin metodiin _[componentDidMount](https://reactjs.org/docs/react-component.html#componentdidmount)_, se on luonteva paikka alustuksille, sillä metodi suoritetaan ennen kuin sovelluksemme renderöidään ensimmäistä kertaa.
 
 Jotta saamme action creatorin _noteInitialization_ käyttöön komponentissa _App_ tarvitsemme jälleen _connect_-metodin apua:
 


### PR DESCRIPTION
Match seems to be case sensitive

>An anchor name is the value of either the name or id attribute when used in the context of anchors. Anchor names must observe the following rules:
> 
> **Uniqueness**: Anchor names must be unique within a document. Anchor names that differ only in case may not appear in the same document.
> **String matching**: Comparisons between fragment identifiers and anchor names must be done by exact (case-sensitive) match.

https://www.w3.org/TR/html4/struct/links.html#h-12.2.1