### PR TITLE
fix typo in 5c

### DIFF
--- a/src/content/5/en/part5c.md
+++ b/src/content/5/en/part5c.md
@@ -538,7 +538,7 @@ would cause an error:
 The error message suggests to use <i>getAllByRole</i>. Test could be fixed as follows:
 
 ```js
-const inputs = screen.getByRole('textbox')
+const inputs = screen.getAllByRole('textbox')
 
 userEvent.type(input[0], 'testing a form...' )
 ```

--- a/src/content/5/fi/osa5c.md
+++ b/src/content/5/fi/osa5c.md
@@ -533,7 +533,7 @@ aiheuttaisi virheen:
 Virheilmoitus ehdottaa käytettäväksi metodia <i>getAllByRole</i> (jos tilanne ylipäätään on se mitä halutaan). Testi korjautuisi seuraavasti:
 
 ```js
-const inputs = screen.getByRole('textbox')
+const inputs = screen.getAllByRole('textbox')
 
 userEvent.type(input[0], 'testing a form...' )
 ```


### PR DESCRIPTION
changed the function from getByRole to getAllByRole